### PR TITLE
Fix navbar URL validation for Mintlify deployment

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -141,7 +141,7 @@
     "links": [
       {
         "label": "Support",
-        "href": "/support"
+        "href": "mailto:support@scam.ai"
       }
     ]
   },


### PR DESCRIPTION
- Change support link from relative path '/support' to 'mailto:support@scam.ai'
- Ensures compliance with Mintlify's URL validation requirements
- Maintains direct support contact functionality while fixing deployment issues